### PR TITLE
[✨] Add --pose-backend flag for per-run pose engine selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,10 @@ SKISENSE_ROI_PADDING=0.3
 #             View-invariant joint angles incl. ankle. ~1-2 s/frame.
 #   - yolo11: YOLO11-Pose. 2D COCO-17 keypoints. CPU/MPS/CUDA. Fast and
 #             light, but no foot landmark (ankle angle shown as N/A).
+#             This is the pre-migration engine, kept as a supported
+#             fallback for machines without CUDA.
+# This value is the persistent default; `run.py --pose-backend {sam3d,yolo11}`
+# overrides it for a single run.
 # Default: sam3d
 SKISENSE_POSE_BACKEND=sam3d
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ the best-scoring frame, and per-joint readouts are written to disk.
 
 - **Person detection** — YOLOv8x
 - **Pose estimation** — selectable backend: SAM 3D Body (3D MHR-21,
-  default) or YOLO11-Pose (2D COCO-17). See [Pose backends](#pose-backends)
+  default) or YOLO11-Pose (2D COCO-17), switchable per run via
+  `--pose-backend`. See [Pose backends](#pose-backends)
 - **Joint-angle evaluation** — knee / hip / ankle in 3D, shoulder tilt in 2D
 - **Overall score** — 0–100 over the angles that can be measured
 - **Multi-person tracking** — Deep SORT keeps a stable ID across frames
@@ -41,9 +42,10 @@ pip install -r requirements-sam3d.txt
 Run:
 
 ```bash
-python run.py video.mp4            # process a video (input/video.mp4 by default)
-python run.py --fast video.mp4     # skip per-frame detect/track; one pass per frame
-python run.py skier.jpg --image    # process a single image
+python run.py video.mp4                     # process a video (input/video.mp4 by default)
+python run.py --fast video.mp4              # skip per-frame detect/track; one pass per frame
+python run.py --pose-backend yolo11 video.mp4   # legacy 2D pose engine (no CUDA needed)
+python run.py skier.jpg --image             # process a single image
 ```
 
 Output is written to `output/YYYYMMDD_HHMMSS/` (`video_pose.mp4`,
@@ -56,19 +58,35 @@ Output is written to `output/YYYYMMDD_HHMMSS/` (`video_pose.mp4`,
 
 ## Pose backends
 
-The pose engine is selected in `.env`:
+Two pose engines ship. `yolo11` is the pre-migration engine and remains
+fully supported, so falling back to the older 2D behaviour is a one-flag
+operation.
+
+Per run, on the command line:
+
+```bash
+python run.py --pose-backend sam3d     # 3D engine (default)
+python run.py --pose-backend yolo11    # legacy 2D engine
+```
+
+Or as a persistent default in `.env`:
 
 ```bash
 SKISENSE_POSE_BACKEND=sam3d    # default: SAM 3D Body (3D, CUDA required)
 SKISENSE_POSE_BACKEND=yolo11   # YOLO11-Pose (2D, runs on CPU/MPS/CUDA)
 ```
 
+The CLI flag wins over `.env`. The active engine is printed on the
+`- Pose:` line of the startup banner.
+
 - **SAM 3D Body** — 3D MHR keypoints + body mesh; view-invariant joint
   angles including the ankle. CUDA required; ~1–2 s/frame.
 - **YOLO11-Pose** — 2D COCO-17 keypoints; fast and CPU-capable, but the
   ankle angle is `N/A` (no foot landmark).
 
-Full comparison, settings, and trade-offs:
+Scores from the two engines are **not** comparable: the angles are
+measured differently, and `yolo11` averages 5 items where `sam3d`
+averages 7. Full comparison, settings, and trade-offs:
 [`docs/pose_backends.md`](docs/pose_backends.md).
 
 ## Architecture

--- a/README_ja.md
+++ b/README_ja.md
@@ -18,7 +18,7 @@ SkiSense は映像中のスキーヤーを検出し、姿勢を推定して、�
 ## 主な機能
 
 - **人物検出** — YOLOv8x
-- **骨格推定** — 既定は SAM 3D Body（3D MHR-21）、`.env` で YOLO11-Pose（2D COCO-17）に切替可能。[姿勢推定バックエンド](#姿勢推定バックエンド)を参照
+- **骨格推定** — 既定は SAM 3D Body（3D MHR-21）、`--pose-backend` で実行ごとに YOLO11-Pose（2D COCO-17）へ切替可能。[姿勢推定バックエンド](#姿勢推定バックエンド)を参照
 - **関節角度評価** — 膝・股関節・足首を 3D、肩の水平傾きを 2D で評価
 - **総合スコア** — 算出可能な項目を 0〜100 点で評価
 - **複数人トラッキング** — Deep SORT によるフレーム間の ID 一貫性
@@ -39,9 +39,10 @@ pip install -r requirements-sam3d.txt
 実行:
 
 ```bash
-python run.py video.mp4            # 動画を処理（既定 input/video.mp4）
-python run.py --fast video.mp4     # フレーム単位の検出/追跡を省略し 1 回の推論に集約
-python run.py skier.jpg --image    # 静止画を処理
+python run.py video.mp4                          # 動画を処理（既定 input/video.mp4）
+python run.py --fast video.mp4                   # フレーム単位の検出/追跡を省略し 1 回の推論に集約
+python run.py --pose-backend yolo11 video.mp4    # 旧来の 2D エンジン（CUDA 不要）
+python run.py skier.jpg --image                  # 静止画を処理
 ```
 
 出力は `output/YYYYMMDD_HHMMSS/`（`video_pose.mp4` / `best_shot.jpg` / 入力のコピー）。
@@ -52,17 +53,32 @@ python run.py skier.jpg --image    # 静止画を処理
 
 ## 姿勢推定バックエンド
 
-姿勢推定エンジンは `.env` で選択する。
+姿勢推定エンジンは 2 種類ある。`yolo11` は移行前のエンジンであり、非推奨ではなく
+正式にサポートを継続している。旧来の 2D 動作へはフラグ 1 つで戻せる。
+
+実行ごとに切り替える場合はコマンドラインで指定する。
+
+```bash
+python run.py --pose-backend sam3d     # 3D エンジン（既定）
+python run.py --pose-backend yolo11    # 旧来の 2D エンジン
+```
+
+恒久的な既定値は `.env` で設定する。
 
 ```bash
 SKISENSE_POSE_BACKEND=sam3d    # 既定: SAM 3D Body（3D・CUDA 必須）
 SKISENSE_POSE_BACKEND=yolo11   # YOLO11-Pose（2D・CPU/MPS/CUDA 可）
 ```
 
+CLI フラグが `.env` より優先される。有効なエンジンは起動時バナーの `- Pose:` 行に
+表示される。
+
 - **SAM 3D Body** — 3D MHR キーポイント + 人体メッシュ。視点不変の関節角度（足首含む）。CUDA 必須、~1–2 秒/フレーム。
 - **YOLO11-Pose** — 2D COCO-17。高速で CPU でも動くが、足先ランドマークがないため足首角度は `N/A`。
 
-比較表・設定・使い分けの詳細は [`docs/pose_backends_ja.md`](docs/pose_backends_ja.md) を参照。
+両エンジンのスコアは**比較できない**。角度の測り方が異なるうえ、`yolo11` は 5 項目、
+`sam3d` は 7 項目の平均を取るためである。比較表・設定・使い分けの詳細は
+[`docs/pose_backends_ja.md`](docs/pose_backends_ja.md) を参照。
 
 ## アーキテクチャ
 

--- a/docs/pose_backends.md
+++ b/docs/pose_backends.md
@@ -2,24 +2,40 @@
 
 **English** | [日本語](pose_backends_ja.md)
 
-SkiSense supports two pose estimation engines, selected via
-`SKISENSE_POSE_BACKEND` in `.env`:
+SkiSense supports two pose estimation engines. `yolo11` is the
+pre-migration engine and stays fully supported, so switching back to the
+older 2D behaviour is always a one-flag operation.
+
+**Per run — CLI flag** (highest priority):
+
+```bash
+python run.py --pose-backend yolo11 video.mp4     # legacy 2D engine
+python run.py --pose-backend sam3d  video.mp4     # 3D engine
+python run.py --pose-backend yolo11 skier.jpg --image
+```
+
+**Persistent default — `.env`:**
 
 ```bash
 SKISENSE_POSE_BACKEND=sam3d    # default: SAM 3D Body (3D, high accuracy)
 SKISENSE_POSE_BACKEND=yolo11   # YOLO11-Pose (2D, light and fast)
 ```
 
+Resolution order is `--pose-backend` → `SKISENSE_POSE_BACKEND` → `sam3d`.
+The selected engine is echoed on the `- Pose:` line of the startup banner,
+so you can confirm which one is active before a long run.
+
 The person detection (YOLOv8x), tracking (Deep SORT), zoom, and scoring
 pipeline are shared; only the pose estimation step swaps out. Each backend
 declares its own topology (`pose_topology.py`), and `analyze_ski_pose`
-plus the drawing helpers follow it automatically.
+plus the drawing helpers follow it automatically. `--fast`, `--high`, and
+`--target-mode` work with either engine.
 
 ## Comparison
 
 | Aspect | SAM 3D Body | YOLO11-Pose |
 |---|---|---|
-| `SKISENSE_POSE_BACKEND` | `sam3d` (default) | `yolo11` |
+| Backend name | `sam3d` (default) | `yolo11` (legacy fallback) |
 | Topology | MHR-21 (body + feet + wrists) | COCO-17 |
 | Dimensions | 3D (camera space) + 2D projection | 2D image space only |
 | Joint angles | Knee / hip / ankle in 3D (view-invariant) | Knee / hip in 2D |
@@ -55,7 +71,10 @@ keypoints (body, feet, wrists).
 
 ## YOLO11-Pose (`yolo11`)
 
-Ultralytics' 2D pose model. Estimates COCO-17 keypoints per ROI.
+Ultralytics' 2D pose model, and the engine SkiSense used before the SAM
+3D Body migration. Estimates COCO-17 keypoints per ROI. It is retained
+deliberately — not deprecated — so results from the older pipeline stay
+reproducible and CUDA-less machines remain usable.
 
 - **Strengths**: Runs on CPU. A few ms per frame, suitable for quick
   checks, near-real-time use, or machines without CUDA. Weights
@@ -75,6 +94,23 @@ Ultralytics' 2D pose model. Estimates COCO-17 keypoints per ROI.
   view-invariant 3D angles, ankle evaluation, and mesh pay off when CUDA
   is available and processing time is acceptable.
 - **Quick checks / no-CUDA machines / first-pass batch screening** → `yolo11`.
+- **Reproducing pre-migration output** → `yolo11`. It is the same engine
+  and the same COCO-17 topology as before the SAM 3D Body migration.
+
+## Scores are not comparable across backends
+
+Switching backends changes the measured numbers, not just their
+precision, so do not compare a `sam3d` score against a `yolo11` score:
+
+- Knee / hip angles come from 3D camera-space vectors under `sam3d` and
+  from projected image-plane coordinates under `yolo11`. The same posture
+  yields different degrees at oblique viewpoints.
+- The overall score is the mean over the joints that could be measured.
+  `yolo11` cannot measure the two ankle angles, so its mean is taken over
+  5 items instead of 7.
+
+Fix the backend for a given comparison — for example when reviewing a
+season's clips as a set.
 
 ## Known limitations
 
@@ -82,4 +118,10 @@ Ultralytics' 2D pose model. Estimates COCO-17 keypoints per ROI.
   the info panel shows `N/A`.
 - `sam3d` requires CUDA. Selecting `sam3d` on an environment where
   `SKISENSE_DEVICE` does not resolve to CUDA raises a `RuntimeError` at
-  backend construction. Switch to `yolo11` or run on a CUDA machine.
+  backend construction, naming the `--pose-backend yolo11` fallback.
+- `sam3d` does not expose per-joint confidence, so the backend fills
+  visibility with `1.0` for every joint it uses. As a consequence
+  `SKISENSE_POSE_VISIBILITY_THRESHOLD` and
+  `SKISENSE_POSE_VISIBILITY_THRESHOLD_LEGS` have no effect under `sam3d`;
+  occluded joints are still scored from the model's estimate. Both
+  settings remain effective under `yolo11`.

--- a/docs/pose_backends_ja.md
+++ b/docs/pose_backends_ja.md
@@ -2,24 +2,40 @@
 
 [English](pose_backends.md) | **日本語**
 
-SkiSense は姿勢推定エンジンを 2 種類から選べる。`.env` の
-`SKISENSE_POSE_BACKEND` で切り替える。
+SkiSense は姿勢推定エンジンを 2 種類から選べる。`yolo11` は移行前のエンジンで
+あり、非推奨ではなく正式にサポートを継続している。したがって旧来の 2D 動作へは
+常にフラグ 1 つで戻せる。
+
+**実行ごとの切り替え — CLI フラグ**（最優先）:
+
+```bash
+python run.py --pose-backend yolo11 video.mp4     # 旧来の 2D エンジン
+python run.py --pose-backend sam3d  video.mp4     # 3D エンジン
+python run.py --pose-backend yolo11 skier.jpg --image
+```
+
+**恒久的な既定値 — `.env`:**
 
 ```bash
 SKISENSE_POSE_BACKEND=sam3d    # 既定: SAM 3D Body（3D・高精度）
 SKISENSE_POSE_BACKEND=yolo11   # YOLO11-Pose（2D・軽量・高速）
 ```
 
+優先順位は `--pose-backend` → `SKISENSE_POSE_BACKEND` → `sam3d` である。
+選択されたエンジンは起動時バナーの `- Pose:` 行に出力されるため、長時間の
+処理を始める前にどちらが有効か確認できる。
+
 人物検出（YOLOv8x）・トラッキング（Deep SORT）・ズーム・スコアリングの
 パイプラインは共通で、姿勢推定部だけが差し替わる。各バックエンドは自身の
 トポロジ（`pose_topology.py`）を宣言し、`analyze_ski_pose` と描画ヘルパーが
-それに自動追従する。
+それに自動追従する。`--fast` / `--high` / `--target-mode` はどちらのエンジン
+でも動作する。
 
 ## 比較表
 
 | 項目 | SAM 3D Body | YOLO11-Pose |
 |---|---|---|
-| `SKISENSE_POSE_BACKEND` | `sam3d`（既定） | `yolo11` |
+| バックエンド名 | `sam3d`（既定） | `yolo11`（旧来モード） |
 | トポロジ | MHR-21（体 + 足先 + 手首） | COCO-17 |
 | 次元 | 3D（カメラ座標）+ 2D 投影 | 2D 画像座標のみ |
 | 関節角度 | 膝・股関節・足首を 3D で算出（視点不変） | 膝・股関節を 2D で算出 |
@@ -52,7 +68,10 @@ Meta が 2025-11-19 に公開した単一画像 3D 人体メッシュ復元モ�
 
 ## YOLO11-Pose（`yolo11`）
 
-Ultralytics の 2D 姿勢推定モデル。COCO-17 キーポイントを ROI 単位で推定する。
+Ultralytics の 2D 姿勢推定モデルであり、SAM 3D Body 移行前に SkiSense が使って
+いたエンジンでもある。COCO-17 キーポイントを ROI 単位で推定する。旧パイプライン
+の結果を再現できるようにし、また CUDA 非搭載機でも動かせるようにするため、
+非推奨扱いにせず意図的に維持している。
 
 - **強み**: CPU でも動く。1 フレーム数 ms と高速で、リアルタイム寄りの確認や
   CUDA 非搭載機での利用に向く。重みは自動ダウンロード。
@@ -69,10 +88,29 @@ Ultralytics の 2D 姿勢推定モデル。COCO-17 キーポイントを ROI 単
 - **精密なフォーム分析・本番の可視化** → `sam3d`。視点不変の 3D 角度と足首評価、
   メッシュが活きる。CUDA があり処理時間を許容できる場合。
 - **素早い確認・CUDA 非搭載機・大量バッチの一次スクリーニング** → `yolo11`。
+- **移行前の出力を再現したい場合** → `yolo11`。SAM 3D Body 移行前と同一の
+  エンジン・同一の COCO-17 トポロジである。
+
+## バックエンドをまたいだスコアは比較できない
+
+バックエンドを切り替えると、精度だけでなく測定値そのものが変わる。したがって
+`sam3d` のスコアと `yolo11` のスコアを直接比べてはならない。
+
+- 膝・股関節の角度は、`sam3d` ではカメラ空間の 3D ベクトルから、`yolo11` では
+  画像平面に投影された座標から算出する。同じ姿勢でも斜め視点では度数が異なる。
+- 総合スコアは測定できた関節の平均である。`yolo11` は左右の足首角度を測定できない
+  ため、7 項目ではなく 5 項目の平均になる。
+
+シーズンを通したクリップ群を見比べるときなど、比較を行う場面ではバックエンドを
+固定すること。
 
 ## 既知の制約
 
 - `yolo11` は COCO-17 トポロジのため足首角度を出せない（info panel は `N/A`）。
 - `sam3d` は CUDA 必須。`SKISENSE_DEVICE` が CUDA に解決されない環境で `sam3d` を
-  選ぶと、バックエンド構築時に `RuntimeError` を送出する。`yolo11` に切り替えるか
-  CUDA 環境で実行すること。
+  選ぶと、バックエンド構築時に `RuntimeError` を送出する。エラーメッセージは
+  `--pose-backend yolo11` への切り替えを案内する。
+- `sam3d` は関節ごとの信頼度を公開しないため、使用する関節の visibility は一律
+  `1.0` で埋めている。その結果 `SKISENSE_POSE_VISIBILITY_THRESHOLD` および
+  `SKISENSE_POSE_VISIBILITY_THRESHOLD_LEGS` は `sam3d` では効果を持たず、遮蔽された
+  関節もモデルの推定値のまま採点される。`yolo11` では両設定とも有効である。

--- a/docs/project_details_ja.md
+++ b/docs/project_details_ja.md
@@ -66,6 +66,13 @@ python run.py --fast video.mp4
 python run.py --fast --target-mode largest video.mp4
 ```
 
+姿勢推定エンジンそのものを SAM 3D Body 移行前の 2D パイプラインへ戻す場合は `--pose-backend yolo11` を指定する。CUDA 非搭載機ではこちらが唯一の実行経路となる。
+
+```bash
+python run.py --pose-backend yolo11 video.mp4
+python run.py --pose-backend yolo11 skier.jpg --image
+```
+
 ---
 
 ## ズーム仕様
@@ -100,12 +107,16 @@ SKISENSE_TARGET_SELECTION_MODE=longest
 
 ### 姿勢推定バックエンドの選択
 
-SkiSense は姿勢推定エンジンを `.env` の `SKISENSE_POSE_BACKEND` で切り替えられる。
+SkiSense は姿勢推定エンジンを実行ごとに `--pose-backend` で、恒久的には `.env` の `SKISENSE_POSE_BACKEND` で切り替えられる。優先順位は CLI フラグ → `.env` → 既定値 `sam3d` である。
 
 ```bash
+python run.py --pose-backend yolo11 video.mp4   # この実行のみ 2D エンジン
+
 SKISENSE_POSE_BACKEND=sam3d    # 既定: SAM 3D Body（3D・高精度・CUDA 必須）
 SKISENSE_POSE_BACKEND=yolo11   # YOLO11-Pose（2D・軽量・CPU/MPS/CUDA 可）
 ```
+
+移行にあたり YOLO11-Pose を削除せず残したのは、CUDA 非搭載機での実行経路を確保するためと、移行前の出力を再現できるようにするためである。両者はスコアの母数が異なる（`sam3d` は 7 項目、`yolo11` は足首を測れないため 5 項目）ので、スコアをまたいで比較しないこと。
 
 各モデルの特性・設定・使い分けの詳細は [`pose_backends_ja.md`](pose_backends_ja.md) を参照。
 
@@ -129,8 +140,8 @@ SKISENSE_POSE_BACKEND=yolo11   # YOLO11-Pose（2D・軽量・CPU/MPS/CUDA 可）
 ### モジュール構成
 
 - **`config.py`** — `.env` から全設定を読み込み、型変換とバリデーションを行う
-- **`pose_topology.py`** — MHR-21（現行ランタイム）と COCO-17（参考）の 2 トポロジを定義する。`is_3d` フラグで pose_analyzer が 3D / 2D を切り替える
-- **`backends/`** — 姿勢推定 backend。SAM 3D Body と YOLO11-Pose を内包し、`SKISENSE_POSE_BACKEND` で切替。`PoseBackend` ABC により将来の backend 追加にも備える
+- **`pose_topology.py`** — MHR-21（既定ランタイム）と COCO-17（YOLO11-Pose ランタイム）の 2 トポロジを定義する。`is_3d` フラグで pose_analyzer が 3D / 2D を切り替える
+- **`backends/`** — 姿勢推定 backend。SAM 3D Body と YOLO11-Pose を内包し、`get_backend(backend=...)` が CLI フラグ → `SKISENSE_POSE_BACKEND` → 既定値の順で解決する。`PoseBackend` ABC により将来の backend 追加にも備える
 - **`pose_analyzer.py`** — 純粋関数による関節角度の計算と評価。副作用・I/O なし
 - **`zoom_tracker.py`** — EMA スムージングによる滑走者追尾。検出タイムアウト 30 フレーム
 - **`main.py`** — オーケストレーション。デバイス解決、backend 取得、フレームループ、動画 I/O
@@ -141,7 +152,8 @@ SKISENSE_POSE_BACKEND=yolo11   # YOLO11-Pose（2D・軽量・CPU/MPS/CUDA 可）
 `auto` モード時の優先順位は **MPS > CUDA > CPU**。ただしコンポーネントごとに制約が異なる。
 
 - **YOLOv8x** は CUDA / MPS / CPU に対応、CUDA 時のみ `half=True`、MPS では `half=False`
-- **SAM 3D Body** は CUDA 必須。`device_str` が `cuda` 以外のとき backend は起動時に例外を投げる
+- **SAM 3D Body** は CUDA 必須。`device_str` が `cuda` 以外のとき backend は起動時に例外を投げ、`--pose-backend yolo11` への切り替えを案内する
+- **YOLO11-Pose** は CUDA / MPS / CPU いずれでも動作するため、CUDA 非搭載機の実行経路となる
 - **Deep SORT** は MPS 非対応のため、macOS でも CPU フォールバック
 
 ---

--- a/run.py
+++ b/run.py
@@ -6,9 +6,13 @@ Usage:
 
 Options:
     --high     Enable high precision mode (frame interpolation, video only)
-    --fast     Enable fast full-frame SAM 3D Body mode (video only)
+    --fast     Enable fast full-frame pose mode (video only)
     --target-mode {longest,largest}
                Select the zoom target strategy (video only)
+    --pose-backend {sam3d,yolo11}
+               Select the pose engine, overriding SKISENSE_POSE_BACKEND.
+               "sam3d" is the 3D default; "yolo11" is the legacy 2D engine
+               that also runs on CPU/MPS.
     --image    Process a single image instead of a video
 
 Examples:
@@ -16,15 +20,17 @@ Examples:
     python run.py --high                   # Video: high precision mode
     python run.py --fast                   # Video: fast mode
     python run.py --target-mode largest    # Video: legacy largest-person zoom
+    python run.py --pose-backend yolo11    # Video: legacy 2D pose engine
     python run.py my_ski_video.mp4         # Video: specific file
     python run.py skier.jpg --image        # Image: input/skier.jpg
 
 Configuration:
-    Edit src/skisense/config.py to change settings.
+    Edit .env (see .env.example) to change settings.
 """
 import argparse
 
 from src.skisense import process_image, process_video
+from src.skisense.backends import AVAILABLE_BACKENDS
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -42,13 +48,23 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--fast", action="store_true",
-        help="Use fast full-frame SAM 3D Body mode (video only)",
+        help="Use fast full-frame pose mode (video only)",
     )
     parser.add_argument(
         "--target-mode",
         choices=["longest", "largest"],
         default=None,
         help="Zoom target selection strategy (video only)",
+    )
+    parser.add_argument(
+        "--pose-backend",
+        choices=list(AVAILABLE_BACKENDS),
+        default=None,
+        help=(
+            "Pose engine to use, overriding SKISENSE_POSE_BACKEND. "
+            "'sam3d' is the 3D default (CUDA required); 'yolo11' is the "
+            "legacy 2D engine and runs on CPU/MPS/CUDA."
+        ),
     )
     parser.add_argument(
         "--image", action="store_true",
@@ -64,7 +80,10 @@ if __name__ == "__main__":
             parser.error("--image cannot be combined with --fast")
         if args.target_mode is not None:
             parser.error("--image cannot be combined with --target-mode")
-        process_image(image_file=args.input_file)
+        process_image(
+            image_file=args.input_file,
+            pose_backend_name=args.pose_backend,
+        )
     else:
         if args.high and args.fast:
             parser.error("--high cannot be combined with --fast")
@@ -73,4 +92,5 @@ if __name__ == "__main__":
             high_precision=args.high,
             fast_mode=args.fast,
             target_mode=args.target_mode,
+            pose_backend_name=args.pose_backend,
         )

--- a/src/skisense/backends/__init__.py
+++ b/src/skisense/backends/__init__.py
@@ -1,12 +1,51 @@
 """Pose estimation backend dispatcher.
 
-Exposes ``get_backend(...)`` which selects a concrete ``PoseBackend``
-based on ``SKISENSE_POSE_BACKEND``:
+Exposes ``get_backend(...)`` which selects a concrete ``PoseBackend``:
 
 - ``"sam3d"`` (default): SAM 3D Body, 3D MHR-21, CUDA required.
-- ``"yolo11"``: YOLO11-Pose, 2D COCO-17, CPU/MPS/CUDA capable.
+- ``"yolo11"``: YOLO11-Pose, 2D COCO-17, CPU/MPS/CUDA capable. This is
+  the pre-migration engine, kept as a supported fallback.
+
+Resolution order is ``get_backend(backend=...)`` (i.e. the ``run.py``
+``--pose-backend`` flag) first, then ``SKISENSE_POSE_BACKEND`` in
+``.env``, then the built-in default.
 """
+from typing import Optional
+
+from ..config import AVAILABLE_POSE_BACKENDS
 from .base import PoseBackend
+
+#: Backend names accepted by ``get_backend`` and ``run.py --pose-backend``.
+#: Defined in ``config.py`` so the env-var validation and the CLI choices
+#: cannot drift apart.
+AVAILABLE_BACKENDS = AVAILABLE_POSE_BACKENDS
+
+
+def resolve_backend_name(backend: Optional[str] = None) -> str:
+    """Normalise and validate a backend name.
+
+    Args:
+        backend: Explicit backend name, typically from the CLI. ``None``
+            or an empty string falls back to ``SKISENSE_POSE_BACKEND``.
+
+    Returns:
+        One of ``AVAILABLE_BACKENDS``.
+
+    Raises:
+        ValueError: If ``backend`` is not a known backend name.
+    """
+    from ..config import POSE_BACKEND
+
+    if backend is None or not backend.strip():
+        return POSE_BACKEND
+
+    name = backend.strip().lower()
+    if name not in AVAILABLE_BACKENDS:
+        raise ValueError(
+            f"Unsupported pose backend: {backend!r}. "
+            f"Expected one of {', '.join(AVAILABLE_BACKENDS)}."
+        )
+    return name
 
 
 def get_backend(
@@ -14,13 +53,13 @@ def get_backend(
     device=None,
     use_gpu: bool = False,
     device_str: str = "cpu",
+    backend: Optional[str] = None,
 ) -> PoseBackend:
-    """Build and return the configured pose backend.
+    """Build and return the requested pose backend.
 
-    The backend is chosen by ``SKISENSE_POSE_BACKEND``. Both backends are
-    stateless across image and video flows and share the same
-    ``(entry, analysis)`` contract plus ``estimate_full_frame`` for fast
-    mode, so callers do not need to know which one is active.
+    Both backends are stateless across image and video flows and share the
+    same ``(entry, analysis)`` contract plus ``estimate_full_frame`` for
+    fast mode, so callers do not need to know which one is active.
 
     Args:
         running_mode: Accepted for interface compatibility.
@@ -28,13 +67,14 @@ def get_backend(
         use_gpu: True when CUDA or MPS is active.
         device_str: ``"cuda"``, ``"mps"``, or ``"cpu"``. SAM 3D Body
             requires ``"cuda"`` and raises otherwise.
+        backend: Explicit backend name overriding ``SKISENSE_POSE_BACKEND``.
 
     Returns:
         An initialised ``PoseBackend`` subclass instance.
     """
-    from ..config import POSE_BACKEND
+    name = resolve_backend_name(backend)
 
-    if POSE_BACKEND == "yolo11":
+    if name == "yolo11":
         from .yolo11_backend import Yolo11Backend
         return Yolo11Backend(device=device, use_gpu=use_gpu, device_str=device_str)
 
@@ -42,4 +82,9 @@ def get_backend(
     return Sam3dBackend(device=device, use_gpu=use_gpu, device_str=device_str)
 
 
-__all__ = ["PoseBackend", "get_backend"]
+__all__ = [
+    "AVAILABLE_BACKENDS",
+    "PoseBackend",
+    "get_backend",
+    "resolve_backend_name",
+]

--- a/src/skisense/backends/sam3d_backend.py
+++ b/src/skisense/backends/sam3d_backend.py
@@ -93,10 +93,14 @@ class Sam3dBackend(PoseBackend):
         self._device_str = device_str
         if device_str != "cuda":
             # SAM 3D Body's reference implementation moves batches to CUDA
-            # unconditionally; CPU/MPS paths are unsupported in v1.
+            # unconditionally; CPU/MPS paths are unsupported in v1. Point at
+            # the YOLO11-Pose fallback so non-CUDA machines have a way out.
             raise RuntimeError(
-                "SAM 3D Body backend requires CUDA. "
-                f"Current device_str={device_str!r}."
+                "SAM 3D Body backend requires CUDA "
+                f"(resolved device is {device_str!r}). "
+                "Use the CPU/MPS-capable backend instead: pass "
+                "`--pose-backend yolo11` on the command line, or set "
+                "SKISENSE_POSE_BACKEND=yolo11 in .env."
             )
 
         _ensure_external_on_path()

--- a/src/skisense/config.py
+++ b/src/skisense/config.py
@@ -61,11 +61,23 @@ def _get_float(key: str, default: float, min_val: float = None, max_val: float =
     except ValueError:
         return default
 
-def _get_str(key: str, default: str, valid_options: list = None) -> str:
-    """Get string from environment with validation."""
+def _get_str(key: str, default: str, valid_options: list = None,
+             lower: bool = False) -> str:
+    """Get string from environment with validation.
+
+    Args:
+        key: Environment variable name.
+        default: Value used when unset or invalid.
+        valid_options: Allowed values; anything else falls back to default.
+        lower: Case-fold and strip the value before validating. Use for
+            settings whose options are all lowercase identifiers, so
+            ``YOLO11`` is accepted rather than silently ignored.
+    """
     value = os.getenv(key)
     if value is None:
         return default
+    if lower:
+        value = value.strip().lower()
     if valid_options and value not in valid_options:
         return default
     return value
@@ -102,9 +114,15 @@ YOLO_MODEL = "yolov8x.pt"           # YOLOv8 model file (person detection)
 
 # Pose backend selection:
 #   - "sam3d":  SAM 3D Body (3D MHR-21, CUDA required, higher accuracy)
-#   - "yolo11": YOLO11-Pose (2D COCO-17, CPU/MPS/CUDA, faster, lighter)
+#   - "yolo11": YOLO11-Pose (2D COCO-17, CPU/MPS/CUDA, faster, lighter).
+#               The pre-migration engine, kept as a supported fallback.
+# Single source of truth for the accepted names; re-exported as
+# ``backends.AVAILABLE_BACKENDS`` and used by ``run.py --pose-backend``,
+# which overrides this value for a single run.
+AVAILABLE_POSE_BACKENDS = ("sam3d", "yolo11")
 POSE_BACKEND = _get_str('SKISENSE_POSE_BACKEND', 'sam3d',
-                        valid_options=['sam3d', 'yolo11'])
+                        valid_options=list(AVAILABLE_POSE_BACKENDS),
+                        lower=True)
 
 # --- SAM 3D Body settings (used when POSE_BACKEND == "sam3d") ---------------
 # Weights are gated on HuggingFace; request access on

--- a/src/skisense/image_processor.py
+++ b/src/skisense/image_processor.py
@@ -2,12 +2,13 @@
 
 Analyzes a single ski image (still frame) and saves the annotated result.
 Shares YOLO detection and drawing helpers with ``main.py`` and delegates
-pose estimation to the SAM 3D Body backend.
+pose estimation to the selected pose backend.
 """
 import os
 import shutil
 import time
 from datetime import datetime
+from typing import Optional
 
 import cv2
 
@@ -32,11 +33,16 @@ def _pick_largest_bbox(rects):
     return max(rects, key=lambda r: r[2] * r[3])
 
 
-def process_image(image_file: str = None):
+def process_image(
+    image_file: str = None,
+    pose_backend_name: Optional[str] = None,
+):
     """Analyze a single ski image and save the annotated output.
 
     Args:
         image_file: Image filename in input/ directory. Defaults to "image.jpg".
+        pose_backend_name: "sam3d" or "yolo11". Overrides
+            ``SKISENSE_POSE_BACKEND`` when given.
     """
     if image_file is None:
         image_file = "image.jpg"
@@ -56,6 +62,7 @@ def process_image(image_file: str = None):
         device=device,
         use_gpu=use_gpu,
         device_str=device_str,
+        backend=pose_backend_name,
     )
 
     log_message("=" * 40)

--- a/src/skisense/main.py
+++ b/src/skisense/main.py
@@ -605,10 +605,10 @@ def process_fast_frame(
     height: int,
     target_bbox: Optional[BBox] = None,
 ):
-    """Process one frame with full-frame SAM 3D Body inference only.
+    """Process one frame with full-frame pose inference only.
 
     This skips the separate YOLOv8 detector, Deep SORT, and ROI pose
-    calls. SAM 3D Body's bundled detector handles person localisation.
+    calls; the backend's own full-frame path handles person localisation.
     """
     pose_results = pose_backend.estimate_full_frame(frame)
     primary = select_primary_fast_pose(pose_results, target_bbox)
@@ -642,14 +642,17 @@ def process_video(
     high_precision: bool = False,
     fast_mode: bool = False,
     target_mode: Optional[str] = None,
+    pose_backend_name: Optional[str] = None,
 ):
     """Main processing function for video input.
 
     Args:
         video_file: Video filename in input/ directory. Defaults to "video.mp4".
         high_precision: If True, use frame interpolation for higher accuracy.
-        fast_mode: If True, use full-frame SAM 3D Body without Deep SORT.
+        fast_mode: If True, run full-frame pose estimation without Deep SORT.
         target_mode: "longest" locks zoom to the longest visible track.
+        pose_backend_name: "sam3d" or "yolo11". Overrides
+            ``SKISENSE_POSE_BACKEND`` when given.
     """
     if video_file is None:
         video_file = "video.mp4"
@@ -673,6 +676,7 @@ def process_video(
         device=DEVICE,
         use_gpu=USE_CUDA,
         device_str=DEVICE_STR,
+        backend=pose_backend_name,
     )
 
     log_message("=" * 40)
@@ -804,9 +808,15 @@ def process_video(
     if high_precision:
         log_message("高精度モード: フレーム補間を使用（将来実装予定）")
     if fast_mode and active_target_mode == "longest":
-        log_message("高速モード: SAM 3D Body 内蔵検出と事前選択した主対象bboxを使用")
+        log_message(
+            f"高速モード: {pose_backend.display_name} の全画面推論と"
+            "事前選択した主対象bboxを使用"
+        )
     elif fast_mode:
-        log_message("高速モード: YOLOv8検出と Deep SORT を省略し SAM 3D Body 単体で実行")
+        log_message(
+            "高速モード: YOLOv8検出と Deep SORT を省略し "
+            f"{pose_backend.display_name} 単体で実行"
+        )
     log_message("処理中...")
 
     pbar = tqdm(total=total_frames, desc="Processing", unit="frame")

--- a/src/skisense/pose_topology.py
+++ b/src/skisense/pose_topology.py
@@ -1,13 +1,17 @@
 """Pose topology definitions.
 
-SkiSense uses SAM 3D Body as its pose estimator. SAM 3D Body emits MHR
-(Momentum Human Rig) keypoints; SkiSense consumes the first 63 entries
-covering body, feet, and wrists, providing the joints required for
-ski-posture scoring (shoulders, hips, knees, ankles, toes) plus the
-elbow→wrist arm segment used by the rendered overlay.
+Each pose backend declares the landmark layout it emits, and
+``analyze_ski_pose`` plus the drawing helpers follow that declaration
+instead of hard-coding indices. Two layouts ship today:
 
-The legacy COCO-17 layout remains exported because pose_analyzer's
-visibility-threshold helper and historical tests refer to it.
+- ``MHR_BODY`` — SAM 3D Body's MHR (Momentum Human Rig) keypoints.
+  SkiSense consumes the first 63 entries covering body, feet, and wrists,
+  providing every joint required for ski-posture scoring (shoulders,
+  hips, knees, ankles, toes) plus the elbow→wrist arm segment used by the
+  rendered overlay.
+- ``COCO_17`` — YOLO11-Pose's 2D layout. This was the pre-migration
+  runtime topology and remains fully supported as the CPU/MPS-capable
+  fallback; it has no foot landmark, so ankle angle is unavailable.
 """
 from dataclasses import dataclass
 from typing import Dict, FrozenSet, List, Tuple
@@ -28,7 +32,7 @@ class PoseTopology:
 
 
 # ---------------------------------------------------------------------------
-# COCO-17 (legacy reference; YOLO11-Pose was the previous backend)
+# COCO-17 (emitted by the YOLO11-Pose backend)
 # ---------------------------------------------------------------------------
 #   0:nose   1:left_eye        2:right_eye
 #   3:left_ear  4:right_ear    5:left_shoulder  6:right_shoulder
@@ -63,7 +67,7 @@ COCO_17 = PoseTopology(
 
 
 # ---------------------------------------------------------------------------
-# MHR_BODY (current runtime topology emitted by SAM 3D Body)
+# MHR_BODY (default runtime topology, emitted by SAM 3D Body)
 # ---------------------------------------------------------------------------
 # SAM 3D Body returns the first 70 MHR keypoints. SkiSense keeps the first
 # 63 because wrists are at indices 41/62; entries 21–40 and 42–61 are


### PR DESCRIPTION
## Summary

Follow-up to #11. The SAM 3D Body migration left YOLO11-Pose in the tree as a working fallback, but selecting it required editing `.env` — so returning to the pre-migration 2D behaviour, or running at all on a machine without CUDA, meant a config change rather than a flag.

This adds `--pose-backend {sam3d,yolo11}` so the engine can be chosen per run, and brings the documentation in line with what switching actually implies.

## Changes

### Per-run engine selection

```bash
python run.py --pose-backend yolo11 video.mp4
python run.py --pose-backend yolo11 skier.jpg --image
```

- The flag is threaded through `process_video` / `process_image` into `get_backend(backend=...)`.
- Resolution order is `--pose-backend` → `SKISENSE_POSE_BACKEND` → `sam3d`.
- `resolve_backend_name()` is extracted so the same normalisation and validation apply to both the CLI and the library API.
- The accepted names now live in `config.AVAILABLE_POSE_BACKENDS` and are re-exported as `backends.AVAILABLE_BACKENDS`, so the env-var validation and the argparse `choices` cannot drift apart.
- `SKISENSE_POSE_BACKEND` accepts case and whitespace variants (`YOLO11`, `" yolo11 "`) instead of silently falling back to the default.

### Better failure and reporting

- The SAM 3D Body CUDA guard now names the way out (`--pose-backend yolo11`, or the env var) rather than only stating the requirement.
- Fast-mode log lines report `pose_backend.display_name` instead of hardcoding "SAM 3D Body", so the banner tells you which engine actually ran.
- Docstrings in `main.py`, `image_processor.py`, and `pose_topology.py` that still described SAM 3D Body as *the* pose estimator are now backend-agnostic. `COCO_17` is no longer labelled a legacy reference — it is a supported runtime topology.

### Documentation

- `--pose-backend` and its precedence documented in both READMEs, both `pose_backends` docs, and `project_details_ja.md`.
- `yolo11` framed as a deliberately supported fallback, and noted as the only path on machines without CUDA.
- New section warning that **scores are not comparable across backends**: the angles are measured differently (3D camera space vs projected image plane), and `yolo11` averages 5 items where `sam3d` averages 7, since it cannot measure ankle angle.
- Recorded that `SKISENSE_POSE_VISIBILITY_THRESHOLD` and its legs variant are inert under `sam3d`, because that backend has no per-joint confidence to report and fills visibility with `1.0`. Both remain effective under `yolo11`.

## Verification

Run manually on this branch on a CUDA machine (Windows):

| Path | Result |
|---|---|
| `run.py skier.jpg --image --pose-backend sam3d` | score 42/100, output written |
| `run.py skier.jpg --image --pose-backend yolo11` | score 20/100, output written |
| `run.py IMG_4460.mp4 --pose-backend yolo11` | 435 frames, best shot 60/100 |
| `run.py IMG_4460.mp4 --fast --pose-backend yolo11` | 435 frames, best shot 80/100; banner reported the active engine |
| `run.py --help` | both new and existing flags render correctly |
| `resolve_backend_name` | `None` / `""` / `"   "` → env default; `" SAM3D "` → `sam3d`; unknown name → `ValueError` |
| `SKISENSE_POSE_BACKEND` = `YOLO11` / `" yolo11 "` / `Sam3D` / `bogus` | first three resolve correctly; unknown falls back to `sam3d` (pre-existing behaviour) |

No test framework is configured in this repository, so the above is manual verification rather than an automated suite.

## Not addressed here

- The evaluation thresholds (knee 90–120°, hip 100–130°, ankle 70–90°) were tuned against 2D projected angles and carry over unchanged to the 3D measurements. Re-tuning needs enough footage to calibrate against.
- An unknown `SKISENSE_POSE_BACKEND` value still falls back to the default silently. That is the existing behaviour of every setting in `config.py`; the startup banner's `- Pose:` line is the way to confirm what ran.
